### PR TITLE
fix dict warnings for R18

### DIFF
--- a/include/internal/yamerl_constr.hrl
+++ b/include/internal/yamerl_constr.hrl
@@ -66,7 +66,7 @@
                                           #node_anchor{}]
                                        | undefined,
     current_node_is_leaf = false      :: boolean(),
-    anchors              = dict:new() :: dict()
+    anchors              = dict:new() :: dict:dict(term(), term())
   }).
 
 -endif.

--- a/include/yamerl_types.hrl
+++ b/include/yamerl_types.hrl
@@ -53,7 +53,7 @@
 -type tag_prefix()       :: nonempty_string().
 -type tag_uri()          :: nonempty_string()
                           | {non_specific, [33 | 63]}. %% "!" | "?"
--type tags_table()       :: dict().
+-type tags_table()       :: dict:dict(term(), term()).
 
 %% Node styles, substyles and kinds.
 -type style()            :: block


### PR DESCRIPTION
Remove warnings for:

``` bash
yamerl/include/yamerl_types.hrl:56: Warning: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2

yamerl/include/internal/yamerl_constr.hrl:69: Warning: type dict/0 is deprecated and will be removed in OTP 18.0; use use dict:dict/0 or preferably dict:dict/2
```
