### PR TITLE
Elixir/hex.pm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ debian/files
 /deps/
 /test/
 /ebin/yamerl.app
+
+# Elixir Support
+/_build/
+*.ez

--- a/package.exs
+++ b/package.exs
@@ -1,0 +1,30 @@
+defmodule Poolboy.Mixfile do
+  use Mix.Project
+
+  def project do
+    [
+      app: :yamerl,
+      version: "0.3.1-1",
+      description: description,
+      package: package,
+      deps: []
+    ]
+  end
+
+  defp description do
+    """
+    YAML 1.2 parser in pure Erlang
+    """
+  end
+
+  defp package do
+    [
+      files: ~w(src doc include testsuite rebar.config README.md AUTHORS COPYING),
+      contributors: ["Yakaz", "Jean-Sébastien Pédron"],
+      licenses: ["BSD 2-Clause"],
+      links: %{
+        "GitHub" => "https://github.com/yakaz/yamerl",
+        "Doc" => "https://github.com/yakaz/yamerl/tree/master/doc"
+      }]
+   end
+end


### PR DESCRIPTION
Support for inclusion into Elixir projects.

(You can publish to [hex](https://hex.pm) using `MIX_EXS=package.exs mix hex.publish`)

More info at https://hex.pm/docs/publish
