### PR TITLE
remove obsolate type 'unicode:unicode_char' from specs

### DIFF
--- a/include/yamerl_types.hrl
+++ b/include/yamerl_types.hrl
@@ -40,7 +40,8 @@
 -type encoding()         :: utf8
                           | {utf16, little | big}
                           | {utf32, little | big}.
--type unicode_string()   :: [unicode:unicode_char()].
+-type unicode_char()     :: integer().
+-type unicode_string()   :: [unicode_char()].
 %% unicode:external_unicode_binary() (UTF16/32) not exported.
 -type unicode_binary()   :: unicode:unicode_binary().
 -type unicode_data()     :: unicode_string()


### PR DESCRIPTION
_unicode:unicode_char()_ was removed in R16 😃