### PR TITLE
Update README.md to refer to the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ list its name in your `mix.exs`:
 ```elixir
 def project do
   [
-    deps: [{:yamerl, "~> 0.4.0"}]
+    deps: [{:yamerl, "~> 0.7.0"}]
   ]
 end
 ```


### PR DESCRIPTION
The Elixir part of the README was referring to version `0.4.0` while last version on hex.pm is `0.7.0`.