### PR TITLE
Add handling for binary data in YAML - Tag: !<tag:yaml.org,2002:binary> (!!binary)

### DIFF
--- a/include/yamerl_nodes.hrl
+++ b/include/yamerl_nodes.hrl
@@ -88,6 +88,16 @@
 -type yamerl_float()              :: #yamerl_float{}.
 -type yamerl_simple_float()       :: float().
 
+%% Binary (Core Schema).
+-record(yamerl_binary, {
+    module = undefined            :: atom(),
+    tag    = "!"                  :: tag_uri(),
+    pres   = []                   :: list(),
+    data   = <<"">>               :: bitstring()
+  }).
+-type yamerl_binary()                :: #yamerl_binary{}.
+-type yamerl_simple_binary()         :: bitstring().
+
 %% Erlang atom.
 -record(yamerl_erlang_atom, {
     module = undefined            :: atom(),
@@ -276,6 +286,7 @@
     yamerl_node_int,
     yamerl_node_float,
     yamerl_node_str,
+    yamerl_node_binary,
     yamerl_node_seq,
     yamerl_node_map
   ]).
@@ -286,6 +297,7 @@
     yamerl_node_int_ext,
     yamerl_node_float_ext,
     yamerl_node_str,
+    yamerl_node_binary,
     yamerl_node_seq,
     yamerl_node_map
   ]).

--- a/src/yamerl_constr.erl
+++ b/src/yamerl_constr.erl
@@ -129,6 +129,7 @@
     yamerl_bool/0,
     yamerl_int/0,
     yamerl_float/0,
+    yamerl_binary/0,
     yamerl_timestamp/0,
     yamerl_erlang_atom/0,
     yamerl_erlang_fun/0,
@@ -565,6 +566,7 @@ node_pres(Node) when
   is_record(Node, yamerl_null) orelse
   is_record(Node, yamerl_bool) orelse
   is_record(Node, yamerl_int) orelse
+  is_record(Node, yamerl_binary) orelse
   is_record(Node, yamerl_timestamp) orelse
   is_record(Node, yamerl_erlang_atom) orelse
   is_record(Node, yamerl_erlang_fun) ->

--- a/src/yamerl_node_binary.erl
+++ b/src/yamerl_node_binary.erl
@@ -1,0 +1,99 @@
+%-
+% Copyright (c) 2012-2014 Yakaz
+% Copyright (c) 2016-2018 Jean-Sébastien Pédron <jean-sebastien.pedron@dumbbell.fr>
+% All rights reserved.
+%
+% Redistribution and use in source and binary forms, with or without
+% modification, are permitted provided that the following conditions
+% are met:
+% 1. Redistributions of source code must retain the above copyright
+%    notice, this list of conditions and the following disclaimer.
+% 2. Redistributions in binary form must reproduce the above copyright
+%    notice, this list of conditions and the following disclaimer in the
+%    documentation and/or other materials provided with the distribution.
+%
+% THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+% ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+% IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+% ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+% FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+% DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+% OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+% HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+% LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+% OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+% SUCH DAMAGE.
+
+%% @private
+
+-module(yamerl_node_binary).
+
+-include("yamerl_errors.hrl").
+-include("yamerl_tokens.hrl").
+-include("yamerl_nodes.hrl").
+-include("internal/yamerl_constr.hrl").
+
+%% Public API.
+-export([
+    tags/0,
+    try_construct_token/3,
+    construct_token/3,
+    node_pres/1
+  ]).
+
+-define(TAG, "tag:yaml.org,2002:binary").
+
+%% -------------------------------------------------------------------
+%% Public API.
+%% -------------------------------------------------------------------
+
+tags() -> [?TAG].
+
+try_construct_token(Constr, Node,
+  #yamerl_scalar{tag = #yamerl_tag{uri = {non_specific, "?"}}} = Token) ->
+    try
+        construct_token(Constr, Node, Token)
+    catch
+        _:#yamerl_parsing_error{name = not_a_binary} ->
+            unrecognized
+    end;
+try_construct_token(_, _, _) ->
+    unrecognized.
+
+construct_token(#yamerl_constr{detailed_constr = false},
+  undefined, #yamerl_scalar{text = Text} = Token) ->
+   case catch base64:decode(Text) of
+        <<Result/bitstring>> -> {finished, Result};
+        {'EXIT', _} -> exception(Token)
+    end;
+
+construct_token(#yamerl_constr{detailed_constr = true},
+  undefined, #yamerl_scalar{text = Text} = Token) ->
+   case catch base64:decode(Text) of
+        <<Result/bitstring>> ->
+          Pres = yamerl_constr:get_pres_details(Token),
+          Node = #yamerl_binary{
+            module = ?MODULE,
+            tag    = ?TAG,
+            pres   = Pres,
+            data   = Result
+          },
+          {finished, Node};
+        {'EXIT', _} -> exception(Token)
+    end;
+
+construct_token(_, _, Token) ->
+    exception(Token).
+
+node_pres(Node) ->
+    ?NODE_PRES(Node).
+
+exception(Token) ->
+    Error = #yamerl_parsing_error{
+      name   = not_a_binary,
+      token  = Token,
+      text   = "Invalid binary/Not base64",
+      line   = ?TOKEN_LINE(Token),
+      column = ?TOKEN_COLUMN(Token)
+    },
+    throw(Error).


### PR DESCRIPTION
## Adding handling for binary data in yaml

Binary is a base64 encoded string, tagged with `!<tag:yaml.org,2002:binary>` or `!!binary` [[1](https://yaml.org/type/binary.html)]:
```yaml
#foo: bar
foo: !!binary YmFy
```
The proposed changes interpret the tags denoting binary data. Data is automatically decoded from base64 and represented as an erlang binary `<<bitstring>>`:
```erl
1> yamerl_constr:string("foo: !!binary YmFy").
[[{"foo",<<"bar">>}]]
```


### Notes
* I am extremely new to erlang and possibly don't know what I'm doing here!
* ~~Testing for the **master branch** is currently **failing** on my machine! I can't say if this PR breaks anything else~~ > Tesing is failing on a Windows machine with OTP 22.0 but running fine on a Ubuntu machine - each true for master-branch and PR

Hopefully somebody can review and test this, and possibly add testing or guide me in the right direction to do so.

*I hope to port a current project to elixir and need encoding of binary data in yaml for it. I tried to accomplish this with the proposed modifcation/extension (yaml-elixir has been adapted for this purpose as well and PR will follow after this one).*