### PR TITLE
Travis: Use 'trusty' for older OTP versions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .*.sw?
 *.beam
 
+rebar3
+
 # Files produced by rebar.
 /_build/
 /doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,19 @@
 language: erlang
 sudo: false
 matrix:
-    include:
-      - otp_release: 21.3
-      - otp_release: 20.3
-      - otp_release: 19.3
-      - otp_release: 18.3
-        dist: trusty
-      - otp_release: 17.5
-        dist: trusty
-      - otp_release: R16B03-1
-        dist: trusty
+  include:
+    - otp_release: 21.3
+      env: COVERALLS=true
+    - otp_release: 20.3
+    - otp_release: 19.3
+    - otp_release: 18.3
+      dist: trusty
 
 script:
   - make test
 
 after_success:
-  - ./rebar3 coveralls send
+  - if [[ "$COVERALLS" = true ]]; then ./rebar3 coveralls send; fi
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,8 @@ matrix:
       - otp_release: R16B03-1
         dist: trusty
 
-install:
-  - curl -O -L https://s3.amazonaws.com/rebar3/rebar3
-  - chmod +x rebar3
-
 script:
-  - ./rebar3 do compile,eunit,dialyzer
+  - make test
 
 after_success:
   - ./rebar3 coveralls send

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,17 @@
 
 language: erlang
 sudo: false
-otp_release:
-  - 21.0
-  - 20.3
-  - 19.3
-  - 18.3
-  - 17.5
-  - R16B03-1
+matrix:
+    include:
+      - otp_release: 21.3
+      - otp_release: 20.3
+      - otp_release: 19.3
+      - otp_release: 18.3
+        dist: trusty
+      - otp_release: 17.5
+        dist: trusty
+      - otp_release: R16B03-1
+        dist: trusty
 
 install:
   - curl -O -L https://s3.amazonaws.com/rebar3/rebar3

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ test: $(REBAR)
 clean: $(REBAR)
 	$(REBAR) clean
 
+distclean:
+	rm -rf _build
+	rm -rf ebin
+	rm $(REBAR)
+
 ./rebar3:
 	$(ERL) -noshell -s inets -s ssl \
 	  -eval '{ok, saved_to_file} = httpc:request(get, {"$(REBAR_URL)", []}, [], [{stream, "./rebar3"}])' \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+REBAR := ./rebar3
+REBAR_URL := https://s3.amazonaws.com/rebar3/rebar3
+ERL       ?= erl
+
+.PHONY: compile test
+
+all: compile
+
+compile: $(REBAR)
+	$(REBAR) compile
+
+shell: $(REBAR)
+	$(REBAR) shell
+
+test: $(REBAR)
+	$(REBAR) do compile,eunit,dialyzer
+
+clean: $(REBAR)
+	$(REBAR) clean
+
+./rebar3:
+	$(ERL) -noshell -s inets -s ssl \
+	  -eval '{ok, saved_to_file} = httpc:request(get, {"$(REBAR_URL)", []}, [], [{stream, "./rebar3"}])' \
+	  -s init stop
+	chmod +x ./rebar3

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,4 @@
 %% -*-erlang-*-
 %% vim:ft=erlang:
 
-{cover_enabled, true}.
-{cover_print_enabled, true}.
-{cover_export_enabled, true}.
+{require_min_otp_vsn, "17"}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,10 +1,13 @@
 %% vim:ft=erlang:
 
-case os:getenv("TRAVIS_JOB_ID") of
+case os:getenv("COVERALLS") of
     false -> CONFIG;
     JobId ->
         %% coveralls.io.
         [{plugins, [coveralls]}
+        ,{cover_enabled, true}
+        ,{cover_print_enabled, true}
+        ,{cover_export_enabled, true}
         ,{coveralls_coverdata, "_build/test/cover/eunit.coverdata"}
         ,{coveralls_service_name, "travis-ci"}
         ,{coveralls_service_job_id, JobId}

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -4,9 +4,7 @@ case os:getenv("TRAVIS_JOB_ID") of
     false -> CONFIG;
     JobId ->
         %% coveralls.io.
-        [{plugins, [{coveralls,
-                     {git, "https://github.com/markusn/coveralls-erl",
-                      {branch, "master"}}}]}
+        [{plugins, [coveralls]}
         ,{coveralls_coverdata, "_build/test/cover/eunit.coverdata"}
         ,{coveralls_service_name, "travis-ci"}
         ,{coveralls_service_job_id, JobId}


### PR DESCRIPTION
Use 'trusty' release to run the older OTP tests.

The older OTP versions (18 and earlier) are not available on the newer Travis OS image. With the 'matrix' option an older OS release can be selected for these tests.

 - Removed build targets 17.5 and R16B03-1, as current rebar3 doesn't run well on them
 - Only run coverage send on OTP-21 build
 - Add Makefile for easier building and testing
 - Fetch `coveralls` plugin from Hex
