### PR TITLE
yamerl_parser: Fix detection of a block scalar's end

### DIFF
--- a/src/yamerl_parser.erl
+++ b/src/yamerl_parser.erl
@@ -2597,30 +2597,6 @@ do_parse_block_scalar([$# | _] = Chars, Line, Col, Delta, Parser,
   when Col < Indent ->
     queue_block_scalar_token(Chars, Line, Col, Delta, Parser, Ctx);
 
-%% The next line is less indented than the block scalar, but more than
-%% the parent node: it's an error.
-do_parse_block_scalar([C | _] = Chars, Line, Col, Delta, Parser,
-  #block_scalar_ctx{indent = Indent, style = Style,
-    line = Token_Line, col = Token_Col, output = Output})
-  when C /= $\s andalso Col < Indent ->
-    Token = #yamerl_scalar{
-      style    = block,
-      substyle = Style,
-      text     = lists:reverse(Output),
-      line     = Token_Line,
-      column   = Token_Col,
-      tag      = ?BLOCK_SCALAR_DEFAULT_TAG(Token_Line, Token_Col)
-    },
-    Error  = #yamerl_parsing_error{
-      name   = invalid_block_scalar_indentation,
-      token  = Token,
-      line   = Line,
-      column = Col
-    },
-    Parser1 = add_error(Parser, Error,
-      "Invalid block scalar indentation", []),
-    return(Chars, Line, Col, Delta, Parser1);
-
 %% The next line has a directives end or document end marker: end the
 %% scalar.
 do_parse_block_scalar([C | _] = Chars, Line, 1 = Col, Delta,
@@ -2646,6 +2622,30 @@ do_parse_block_scalar([$-, $-, $-] = Chars, Line, 1 = Col, Delta,
 do_parse_block_scalar([$., $., $.] = Chars, Line, 1 = Col, Delta,
   #yamerl_parser{raw_eos = true} = Parser, Ctx) ->
     queue_block_scalar_token(Chars, Line, Col, Delta, Parser, Ctx);
+
+%% The next line is less indented than the block scalar, but more than
+%% the parent node: it's an error.
+do_parse_block_scalar([C | _] = Chars, Line, Col, Delta, Parser,
+  #block_scalar_ctx{indent = Indent, style = Style,
+    line = Token_Line, col = Token_Col, output = Output})
+  when C /= $\s andalso Col < Indent ->
+    Token = #yamerl_scalar{
+      style    = block,
+      substyle = Style,
+      text     = lists:reverse(Output),
+      line     = Token_Line,
+      column   = Token_Col,
+      tag      = ?BLOCK_SCALAR_DEFAULT_TAG(Token_Line, Token_Col)
+    },
+    Error  = #yamerl_parsing_error{
+      name   = invalid_block_scalar_indentation,
+      token  = Token,
+      line   = Line,
+      column = Col
+    },
+    Parser1 = add_error(Parser, Error,
+      "Invalid block scalar indentation", []),
+    return(Chars, Line, Col, Delta, Parser1);
 
 %%
 %% Content.

--- a/test/parsing/block_scalar_followed_by_end_of_doc.erl
+++ b/test/parsing/block_scalar_followed_by_end_of_doc.erl
@@ -1,0 +1,62 @@
+-module('block_scalar_followed_by_end_of_doc').
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(FILENAME, "test/parsing/" ?MODULE_STRING ".yaml").
+
+single_test_() ->
+    ?_assertMatch(
+       {yamerl_parser,
+        {file, ?FILENAME},
+        [],
+        <<>>,
+        41,
+        true,
+        [],
+        0,
+        42,
+        7,
+        1,
+        false,
+        6,
+        13,
+        utf8,
+        false,
+        undefined,
+        _,
+        _,
+        [],
+        {bcoll,root,0,-1,1,1,-1,1,1},
+        false,
+        false,
+        false,
+        [{impl_key,false,false,undefined,undefined,1,1}],
+        false,
+        false,
+        _,
+        [],
+        0,
+        9,
+        8,
+        undefined,
+        undefined,
+        _,
+        false,
+        [],
+        [
+         {yamerl_stream_end,6,13},
+         {yamerl_doc_end,6,13},
+         {yamerl_scalar,6,1,
+          {yamerl_tag,6,1,{non_specific,"?"}},
+          flow,plain,"new document"},
+         {yamerl_doc_start,5,1,{1,2}, _},
+         {yamerl_doc_end,5,1},
+         {yamerl_scalar,1,5,
+          {yamerl_tag,1,5,{non_specific,"!"}},
+          block,literal,"foo\nbar\nbaz\n"},
+         {yamerl_doc_start,1,1,{1,2}, _},
+         {yamerl_stream_start,1,1,utf8}
+        ]
+       },
+      yamerl_parser:file(?FILENAME)
+    ).

--- a/test/parsing/block_scalar_followed_by_end_of_doc.yaml
+++ b/test/parsing/block_scalar_followed_by_end_of_doc.yaml
@@ -1,0 +1,6 @@
+--- |
+  foo
+  bar
+  baz
+---
+new document


### PR DESCRIPTION
When a block scalar was ended by a document end marker, it was considered an error because of the unexpected indentation (the indentation was less than the body of the block scalar).

The problem was that this error condition was verified before checking this was a document or directives end marker.

Simply swapping the two code blocks fixes the issue.

Fixes #41.