### PR TITLE
Add keep_duplicate_keys for maps in construction

### DIFF
--- a/src/yamerl_constr.erl
+++ b/src/yamerl_constr.erl
@@ -195,6 +195,12 @@ new(Source) ->
 %% happens an exception is raised. When set to `true', the node is
 %% constructed as if it was a plain YAML node without any tag.</dd>
 %% <dd>Default: `false'.</dd>
+%% <dt>`{keep_duplicate_keys, boolean()}'</dt>
+%% <dd>Flag to keep duplicate keys in maps. By default all duplicate keys
+%% in maps/proplists will ignored and the last occurence of a key will
+%% prevail. If this flag is enabled all keys will remain. This flag only
+%% works when the `detailed_constr' flag is set to `true' or proplists
+%% are used instead of maps.</dd>
 %% <dd>Default: `false'</dd>
 %% <dt>`{node_mods, Mods_List}'</dt>
 %% <dd>List of Erlang modules to extend support node types.</dd>

--- a/test/construction/map.erl
+++ b/test/construction/map.erl
@@ -24,6 +24,23 @@ proplist_simple_test_() ->
       ]
     }.
 
+proplist_simple_keep_duplicate_keys_test_() ->
+    {setup,
+      fun setup/0,
+      [
+        ?_assertMatch(
+          [
+            [
+              {"first", [{"item", 1}]},
+              {"second", [{"item", 2}]},
+              {"third", [{"item", 2}, {"item", 3}]}
+            ]
+          ],
+          yamerl_constr:file(?FILENAME, [{detailed_constr, false}, {keep_duplicate_keys, true}])
+        )
+      ]
+    }.
+
 proplist_detailed_test_() ->
     {setup,
       fun setup/0,
@@ -74,6 +91,68 @@ proplist_detailed_test_() ->
                             3}}]}}]}}
           ],
           yamerl_constr:file(?FILENAME, [{detailed_constr, true}])
+        )
+      ]
+    }.
+
+proplist_detailed_keep_duplicate_keys_test_() ->
+    {setup,
+      fun setup/0,
+      [
+        ?_assertMatch(
+          [
+            {yamerl_doc,
+              {yamerl_map,yamerl_node_map,"tag:yaml.org,2002:map",
+                [{line,1},{column,1}],
+                [{{yamerl_str,yamerl_node_str,"tag:yaml.org,2002:str",
+                      [{line,1},{column,1}],
+                      "first"},
+                    {yamerl_map,yamerl_node_map,"tag:yaml.org,2002:map",
+                      [{line,1},{column,9}],
+                      [{{yamerl_str,yamerl_node_str,
+                            "tag:yaml.org,2002:str",
+                            [{line,1},{column,11}],
+                            "item"},
+                          {yamerl_int,yamerl_node_int,
+                            "tag:yaml.org,2002:int",
+                            [{line,1},{column,17}],
+                            1}}]}},
+                  {{yamerl_str,yamerl_node_str,"tag:yaml.org,2002:str",
+                      [{line,2},{column,1}],
+                      "second"},
+                    {yamerl_map,yamerl_node_map,"tag:yaml.org,2002:map",
+                      [{line,2},{column,9}],
+                      [{{yamerl_str,yamerl_node_str,
+                            "tag:yaml.org,2002:str",
+                            [{line,2},{column,11}],
+                            "item"},
+                          {yamerl_int,yamerl_node_int,
+                            "tag:yaml.org,2002:int",
+                            [{line,2},{column,17}],
+                            2}}]}},
+                  {{yamerl_str,yamerl_node_str,"tag:yaml.org,2002:str",
+                      [{line,3},{column,1}],
+                      "third"},
+                    {yamerl_map,yamerl_node_map,"tag:yaml.org,2002:map",
+                      [{line,3},{column,9}],
+                      [{{yamerl_str,yamerl_node_str,
+                              "tag:yaml.org,2002:str",
+                              [{line,3},{column,11}],
+                              "item"},
+                          {yamerl_int,yamerl_node_int,
+                              "tag:yaml.org,2002:int",
+                              [{line,3},{column,17}],
+                              2}},
+                          {{yamerl_str,yamerl_node_str,
+                              "tag:yaml.org,2002:str",
+                              [{line,3},{column,20}],
+                              "item"},
+                          {yamerl_int,yamerl_node_int,
+                              "tag:yaml.org,2002:int",
+                              [{line,3},{column,26}],
+                              3}}]}}]}}
+          ],
+          yamerl_constr:file(?FILENAME, [{detailed_constr, true}, {keep_duplicate_keys, true}])
         )
       ]
     }.
@@ -174,6 +253,81 @@ map_detailed() ->
           ],
           yamerl_constr:file(?FILENAME, [
               {detailed_constr, true},
+              {map_node_format, map}
+            ])
+        )
+      ]
+    }.
+
+map_detailed_keep_duplicate_keys_test_() ->
+    SubMap1 = maps:from_list(
+                [{{yamerl_str,yamerl_node_str,
+                   "tag:yaml.org,2002:str",
+                   [{line,1},{column,11}],
+                   "item"},
+                  {yamerl_int,yamerl_node_int,
+                   "tag:yaml.org,2002:int",
+                   [{line,1},{column,17}],
+                   1}}
+                ]),
+    SubMap2 = maps:from_list(
+                [{{yamerl_str,yamerl_node_str,
+                   "tag:yaml.org,2002:str",
+                   [{line,2},{column,11}],
+                   "item"},
+                  {yamerl_int,yamerl_node_int,
+                   "tag:yaml.org,2002:int",
+                   [{line,2},{column,17}],
+                   2}}]),
+    SubMap3 = maps:from_list(
+                [{{yamerl_str,yamerl_node_str,
+                    "tag:yaml.org,2002:str",
+                    [{line,3},{column,11}],
+                    "item"},
+                    {yamerl_int,yamerl_node_int,
+                    "tag:yaml.org,2002:int",
+                    [{line,3},{column,17}],
+                    2}},
+                  {{yamerl_str,yamerl_node_str,
+                   "tag:yaml.org,2002:str",
+                   [{line,3},{column,20}],
+                   "item"},
+                  {yamerl_int,yamerl_node_int,
+                   "tag:yaml.org,2002:int",
+                   [{line,3},{column,26}],
+                   3}}]),
+    Map = maps:from_list(
+            [{{yamerl_str,yamerl_node_str,"tag:yaml.org,2002:str",
+               [{line,1},{column,1}],
+               "first"},
+              {yamerl_map,yamerl_node_map,"tag:yaml.org,2002:map",
+               [{line,1},{column,9}],
+               SubMap1}},
+             {{yamerl_str,yamerl_node_str,"tag:yaml.org,2002:str",
+               [{line,2},{column,1}],
+               "second"},
+              {yamerl_map,yamerl_node_map,"tag:yaml.org,2002:map",
+               [{line,2},{column,9}],
+               SubMap2}},
+             {{yamerl_str,yamerl_node_str,"tag:yaml.org,2002:str",
+               [{line,3},{column,1}],
+               "third"},
+              {yamerl_map,yamerl_node_map,"tag:yaml.org,2002:map",
+               [{line,3},{column,9}],
+               SubMap3}}]),
+    {setup,
+      fun setup/0,
+      [
+        ?_assertMatch(
+          [
+            {yamerl_doc,
+              {yamerl_map,yamerl_node_map,"tag:yaml.org,2002:map",
+                [{line,1},{column,1}],
+                Map}}
+          ],
+          yamerl_constr:file(?FILENAME, [
+              {detailed_constr, true},
+              {keep_duplicate_keys, true},
               {map_node_format, map}
             ])
         )


### PR DESCRIPTION
This will restore the old behaviour if detailed_constr has been enabled.

Fixes #52