### PR TITLE
GitHub Actions: Stop testing against Erlang/OTP 23

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [23, 24]
+        otp_version: [24]
         os: [ubuntu-latest]
 
     env:


### PR DESCRIPTION
It looks to be unavailable now:

    Run erlef/setup-beam@v1
    Error: Requested Erlang/OTP version (23) not found in version list (...)