### PR TITLE
Allow use of yamerl without starting the app

### DIFF
--- a/src/yamerl_app.erl
+++ b/src/yamerl_app.erl
@@ -66,6 +66,7 @@ params_list() ->
 -spec get_param(atom()) -> term().
 
 get_param(Param) ->
+    application:load(yamerl),
     {ok, Value} = application:get_env(yamerl, Param),
     Value.
 

--- a/src/yamerl_app.erl
+++ b/src/yamerl_app.erl
@@ -65,8 +65,9 @@ params_list() ->
 
 -spec get_param(atom()) -> term().
 
+get_param(node_mods) ->
+    application:get_env(yamerl, node_mods, []);
 get_param(Param) ->
-    application:load(yamerl),
     {ok, Value} = application:get_env(yamerl, Param),
     Value.
 


### PR DESCRIPTION
Forces an application load prior to the `application:get_env/2`