### PR TITLE
Valid SPDX license identifier

### DIFF
--- a/src/yamerl.app.src
+++ b/src/yamerl.app.src
@@ -20,7 +20,7 @@
       ]},
 
     %% Hex.pm package information.
-    {licenses, ["BSD 2-Clause"]},
+    {licenses, ["BSD-2-Clause"]},
     {links, [
         {"GitHub", "https://github.com/yakaz/yamerl"}
       ]}


### PR DESCRIPTION
Update the license identifier to be valid according to SPDX.

Thanks. 🙂 