### PR TITLE
Replace deprecated 'catch ...' with 'try ... catch ... end'

### DIFF
--- a/src/yamerl_constr.erl
+++ b/src/yamerl_constr.erl
@@ -798,7 +798,11 @@ umerge_unsorted(List1, List2) ->
     lists:foldl(Fun, List1, List2).
 
 filter_autodetection_capable_mods([Mod | Rest], Auto) ->
-    catch Mod:module_info(),
+    try
+        _ = Mod:module_info()
+    catch
+        _:_ -> ok
+    end,
     Auto1 = case erlang:function_exported(Mod, try_construct_token, 3) of
         true  -> [Mod | Auto];
         false -> Auto

--- a/src/yamerl_node_binary.erl
+++ b/src/yamerl_node_binary.erl
@@ -62,14 +62,16 @@ try_construct_token(_, _, _) ->
 
 construct_token(#yamerl_constr{detailed_constr = false},
   undefined, #yamerl_scalar{text = Text} = Token) ->
-   case catch base64:decode(Text) of
+   try base64:decode(Text) of
         <<Result/bitstring>> -> {finished, Result};
-        {'EXIT', _} -> exception(Token)
-    end;
+        _ -> exception(Token)
+   catch
+        _:_ -> exception(Token)
+   end;
 
 construct_token(#yamerl_constr{detailed_constr = true},
   undefined, #yamerl_scalar{text = Text} = Token) ->
-   case catch base64:decode(Text) of
+   try base64:decode(Text) of
         <<Result/bitstring>> ->
           Pres = yamerl_constr:get_pres_details(Token),
           Node = #yamerl_binary{
@@ -79,8 +81,10 @@ construct_token(#yamerl_constr{detailed_constr = true},
             data   = Result
           },
           {finished, Node};
-        {'EXIT', _} -> exception(Token)
-    end;
+        _ -> exception(Token)
+   catch
+        _:_ -> exception(Token)
+   end;
 
 construct_token(_, _, Token) ->
     exception(Token).


### PR DESCRIPTION
These are the remaining rebar3 compile warnings on modern Erlang/OTP:

```
src/yamerl_node_binary.erl:65:9: Warning: 'catch ...' is deprecated; please use 'try ... catch ... end' instead.
src/yamerl_node_binary.erl:72:9: Warning: 'catch ...' is deprecated; please use 'try ... catch ... end' instead.
src/yamerl_constr.erl:801:5:      Warning: 'catch ...' is deprecated; please use 'try ... catch ... end' instead.
```

## Changes

### src/yamerl_node_binary.erl
Two `case catch base64:decode(Text) of ... end` expressions rewritten as
`try base64:decode(Text) of ... catch ... end`. The new form routes:

- bitstring results → `{finished, ...}`,
- non-bitstring results → `exception(Token)`,
- raised exceptions → `exception(Token)`.

This matches the original intent (only valid base64 → `{finished, ...}`,
everything else → `exception(Token)`).

### src/yamerl_constr.erl
The defensive `catch Mod:module_info()` is replaced with a scoped
`try _ = Mod:module_info() catch _:_ -> ok end`. The `try` block is
intentionally limited to the `module_info/0` call so that errors from
subsequent operations (`erlang:function_exported/3`, list operations)
continue to propagate, exactly as before.

## Verification

- `rebar3 compile` — no warnings
- `rebar3 as test compile` — no warnings
- `rebar3 xref` — clean
- `rebar3 eunit` — 254 tests, 0 failures